### PR TITLE
README.rst: Removed grave accent quotes around example command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,4 +12,4 @@ Usage
 
 To get a tree of your local requirements and dependecies use simply do::
 
-`$ piptree requirements.txt`
+$ piptree requirements.txt


### PR DESCRIPTION
Cleans up the rendering a bit.